### PR TITLE
Workaround for backwards seeking in MPV player

### DIFF
--- a/y4m/writer.py
+++ b/y4m/writer.py
@@ -46,5 +46,8 @@ class Writer(object):
     def _encode_frame(self, frame):
         assert len(frame.buffer) == self._frame_size()
         data = self._encode_headers(frame.headers)
-        self._fd.write(b'FRAME ' + data + b'\n')
+        self._fd.write(b'FRAME')
+        if len(data) > 0:
+            self._fd.write(b' ' + data)
+        self._fd.write(b'\n')
         self._fd.write(frame.buffer)


### PR DESCRIPTION
This fixs prevents an extra space being written to a frame header when the frame.headers dictionary is empty.
Though this extra space in a frame header seems to be legal y4m, MPV media player apparently refuses to seek backwards if y4m file frame headers contain any data.